### PR TITLE
refact: successfully parse sources with comment befire object name

### DIFF
--- a/src/RetrieveDDL.hs
+++ b/src/RetrieveDDL.hs
@@ -38,7 +38,9 @@ import Utils ( clearSqlSource,
                isSpace,
                strip,
                parseMatch,
-               safeValueByIndex
+               safeValueByIndex,
+               sqlComment,
+               sqlEndLineComment
              )
 
 data ByTypeLists = ByTypeLists {
@@ -517,6 +519,7 @@ retrieveSourcesDDL opts = do
                                  spaces
                                  t'  <- stringCSI type'
                                  spaces
+                                 comments <- many (sqlComment <|> (sqlEndLineComment >>= return . ("\n" ++))<|> (space >> spaces >> return " ") )
             
                                  n' <- try $ do string "\""
                                                 n <- stringCSI name
@@ -526,7 +529,7 @@ retrieveSourcesDDL opts = do
                                  x <- many anyChar
                                  let nameMismatchInCode = not $ if isNameCaseSensitive then n' == name else map toUpper n' == map toUpper name
                                  return $ 
-                                   t' ++ " " ++
+                                   t' ++ " " ++ concat (dropWhileEnd (==" ") comments) ++
                                    case () of
                                           _
                                             | isNameCaseSensitive -> "\"" ++ name ++ "\""

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -9,7 +9,9 @@ module Utils
    isSpace,
    strip,
    parseMatch,
-   safeValueByIndex
+   safeValueByIndex,
+   sqlComment,
+   sqlEndLineComment
   )
 where
 


### PR DESCRIPTION
in previous versions a warning was printed in such cases